### PR TITLE
add basic support for ppc64le, riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,17 @@ BENCH_OPTS   ?= -v -bench=. -run="^_" -benchmem
 TEST_PATH    ?= ./...
 DBG 		 = 1
 OPTS_ENV	 =
+OPTS_TAGS    ?= -tags noasm
+ARCH = $(shell uname -m)
+
+ifeq ($(ARCH), ppc64le)
+	NOASM+=1
+endif
+
+ifeq ($(ARCH), riscv64)
+	NOASM+=1
+	OPTS_TAGS+= -timeout 0
+endif
 
 ifeq ($(NOASM),1)
 	OPTS+=$(OPTS_TAGS)

--- a/dh/csidh/fp511.go
+++ b/dh/csidh/fp511.go
@@ -1,3 +1,5 @@
+// +build noasm amd64 arm64 ppc64le riscv64
+
 package csidh
 
 import (

--- a/drbg/internal/aes/aes_test.go
+++ b/drbg/internal/aes/aes_test.go
@@ -1,6 +1,8 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// +build noasm amd64 arm64 ppc64le riscv64
+
 
 package aes
 

--- a/drbg/internal/aes/cipher.go
+++ b/drbg/internal/aes/cipher.go
@@ -1,6 +1,7 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// +build noasm amd64 arm64 ppc64le riscv64
 
 package aes
 

--- a/drbg/internal/aes/cipher_noasm.go
+++ b/drbg/internal/aes/cipher_noasm.go
@@ -1,0 +1,27 @@
+// +build noasm ppc64le riscv64
+
+package aes
+
+import(
+        "errors"
+)
+
+type AESAsm struct {
+}
+
+func (a *AESAsm) SetKey(key []byte) error {
+        panic("NotImplemented")
+        return errors.New("ErrNotImplemented")
+}
+
+func (a *AESAsm) Encrypt(dst, src []byte) {
+        panic("NotImplemented")
+}
+
+func (a *AESAsm) Decrypt(dst, src []byte) {
+        panic("NotImplemented")
+}
+
+func expandKey(key []byte, enc, dec []uint32) {
+        expandKeyGo(key, enc, dec)
+}

--- a/drbg/internal/aes/generic.go
+++ b/drbg/internal/aes/generic.go
@@ -1,6 +1,7 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// +build noasm amd64 arm64 ppc64le riscv64
 
 // This Go implementation is derived in part from the reference
 // ANSI C implementation, which carries the following notice:


### PR DESCRIPTION
This change set modifies build metadata to add support for ppc64le
(POWER9) and riscv64 (RISC-V).  The arm64 and amd64 assembler
implementations are architecture specific and do not support ppc64le or
riscv64. On ppc64le or riscv64 a generic implementation is chosen.  The
drbg/internal/aes/cipher_noasm.go file was written by @mixmasala and
myself.

The csidh and sidh tests are extremely slow (>30m) on RISC-V using the
sifive,u54-mc (HiFive Unleashed) development board. The test timeout is
set to infinity on RISC-V by the top level Makefile as at least one test
does not finish within the default 10 minutes on RISC-V. On RISC-V the
csidh test finishes after around 30 minutes, the sidh test finishes
after around 71 minutes.

These changes were tested with amd64 (Intel Core i7), arm64 (Raspberry
Pi 4b), ppc64le (Talos POWER9, PowerNV T2P9D01 REV 1.00), and riscv64
(HighFive Unleashed, rv64imafdc,sifive,u54-mc).

The kernel versions of those systems follows:

Linux rpi4 5.13.0-1009-raspi #10-Ubuntu SMP PREEMPT Mon Oct 25 13:58:43
UTC 2021 aarch64 aarch64 aarch64 GNU/Linux

Linux i7 5.8.0-63-generic #71-Ubuntu SMP Tue Jul 13 15:59:12 UTC 2021
x86_64 x86_64 x86_64 GNU/Linux

Linux power9 5.11.0-34-generic #36-Ubuntu SMP Thu Aug 26 19:19:54 UTC
2021 ppc64le ppc64le ppc64le GNU/Linux

Linux risc-v-unleashed-000 5.11.0-1022-generic #23~20.04.1-Ubuntu SMP
Thu Oct 21 10:16:27 UTC 2021 riscv64 riscv64 riscv64 GNU/Linux